### PR TITLE
fix: explicitly disable dictation input auto enable

### DIFF
--- a/src/macOS/disableDictationInputAutoEnable.ts
+++ b/src/macOS/disableDictationInputAutoEnable.ts
@@ -1,0 +1,12 @@
+import { execSync } from "child_process";
+import { ERR_MACOS_UNABLE_UPDATE_SYSTEM_DEFAULTS } from "../errors";
+
+export function disableDictationInputAutoEnable(): void {
+  try {
+    execSync(
+      "defaults write com.apple.HIToolbox AppleDictationAutoEnable -bool false"
+    );
+  } catch (_) {
+    throw new Error(ERR_MACOS_UNABLE_UPDATE_SYSTEM_DEFAULTS);
+  }
+}

--- a/src/macOS/setup.ts
+++ b/src/macOS/setup.ts
@@ -1,6 +1,7 @@
 import { checkVersion } from "./checkVersion";
 import { enableAppleScriptControlSystemDefaults } from "./enableAppleScriptControlSystemDefaults";
 import { disableSplashScreenSystemDefaults } from "./disableSplashScreenSystemDefaults";
+import { disableDictationInputAutoEnable } from "./disableDictationInputAutoEnable";
 import { isSipEnabled } from "./isSipEnabled";
 import { writeDatabaseFile } from "./writeDatabaseFile";
 import { updateTccDb } from "./updateTccDb";
@@ -16,6 +17,7 @@ export async function setup(): Promise<void> {
   checkVersion();
   enableAppleScriptControlSystemDefaults();
   disableSplashScreenSystemDefaults();
+  disableDictationInputAutoEnable();
 
   try {
     updateTccDb();


### PR DESCRIPTION
## Intro

When I started using `guidepup` for a11y testing of [Intergalactic](https://github.com/semrush/intergalactic) repository sometimes tests were falling. Instead of an expected text `.lastSpokenPhrase()` was returning "Dictation system dialog To use Dictation, you need to select a microphone or connect an external microphone. You can configure your microphone in Dictation preferences. To use Dictation, you need to select a microphone or connect an external microphone." or other texts from the Dictation system dialog.

The worst things were that this was not reproducible on local machine, bug was appearing only about every 8th run and the only way to reproduce it outside of our repository was to copy whole test code (I tried to run parts many times but it was not reproducing at all).

## Unexpected behaviour 

Sometimes (not stably) when VoiceOver focuses on text input, MacOS recommends user to enable dictation feature with a system dialog.

## Solution

After little remote (on ci) interactions with dictation dialog, the "Never ask again" button was spotted. Diffing system defaults before and after clicking the button uncovered important field – `com.apple.HIToolbox AppleDictationAutoEnable`.

Setting that field to `false` value resolved the issue in our repository. As far as the bug is very weird and hard for debugging, I suppose this change would be very valuable for other users of guidepup.

@cmorten, is that change is really valuable or I have missed something in documentation (again 😁) ?