### PR TITLE
[#3] Fix `macos-12` DND

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         os:
           [
             macos-11,
-            # macos-12,
+            macos-12,
             macos-latest,
             windows-2019,
             windows-2022,

--- a/src/macOS/enableDoNotDisturb.ts
+++ b/src/macOS/enableDoNotDisturb.ts
@@ -4,13 +4,12 @@ import { ERR_MACOS_FAILED_TO_ENABLE_DO_NOT_DISTURB } from "../errors";
 import { runAppleScript } from "./runAppleScript";
 import { promisify } from "util";
 
-// source https://github.com/sindresorhus/do-not-disturb/issues/9
+// REF: https://github.com/sindresorhus/do-not-disturb/issues/9
 const enableFocusModeShellscript = `
 defaults write com.apple.ncprefs.plist dnd_prefs -data 62706C6973743030D60102030405060708080A08085B646E644D6972726F7265645F100F646E64446973706C6179536C6565705F101E72657065617465644661636574696D6543616C6C73427265616B73444E445875736572507265665E646E64446973706C61794C6F636B5F10136661636574696D6543616E427265616B444E44090808D30B0C0D070F1057656E61626C6564546461746556726561736F6E093341C2B41C4FC9D3891001080808152133545D6C828384858C9499A0A1AAACAD00000000000001010000000000000013000000000000000000000000000000AE && 
 killall usernoted && killall ControlCenter
 `;
 
-// source https://www.reddit.com/r/applescript/comments/r9nnil/enable_do_not_disturb_on_monterey/
 const enableFocusModeAppleScript = `
 set timeoutSeconds to 5.0
 
@@ -39,18 +38,14 @@ my withTimeout(closeSystemPreferences, timeoutSeconds)
 export async function enableDoNotDisturb() {
   const platformMajor = Number(os.version().split("Version ")[1].split(".")[0]);
 
-  if (platformMajor <= 20) {
-    try {
+  try {
+    if (platformMajor <= 20) {
       await promisify(exec)(enableFocusModeShellscript);
-    } catch (_) {
-      throw new Error(ERR_MACOS_FAILED_TO_ENABLE_DO_NOT_DISTURB);
-    }
-  } else {
-    // From MacOS 12 Monterey (Darwin 21) there is no known way to enable DND via system defaults
-    try {
+    } else {
+      // From MacOS 12 Monterey (Darwin 21) there is no known way to enable DND via system defaults
       await runAppleScript(enableFocusModeAppleScript);
-    } catch (e) {
-      throw new Error(ERR_MACOS_FAILED_TO_ENABLE_DO_NOT_DISTURB);
     }
+  } catch {
+    throw new Error(ERR_MACOS_FAILED_TO_ENABLE_DO_NOT_DISTURB);
   }
 }

--- a/src/macOS/enableDoNotDisturb.ts
+++ b/src/macOS/enableDoNotDisturb.ts
@@ -16,8 +16,7 @@ set timeoutSeconds to 5.0
 
 set openSystemPreferences to "tell application \\"System Preferences\\" to activate"
 
-set clickNotificationAndFocusButton to "click UI Element \\"Notifications
-& Focus\\" of scroll area 1 of window \\"System Preferences\\" of application process \\"System Preferences\\""
+set clickNotificationAndFocusButton to "click UI Element 8 of scroll area 1 of window \\"System Preferences\\" of application process \\"System Preferences\\""
 
 set clickFocusTab to "click radio button \\"Focus\\" of tab group 1 of window \\"Notifications & Focus\\" of application process \\"System Preferences\\""
 

--- a/src/windows/installNvda.ts
+++ b/src/windows/installNvda.ts
@@ -1,7 +1,7 @@
 import decompress from "decompress";
 import { get } from "https";
 import { createWriteStream, mkdtempSync, rmSync } from "fs";
-import { join, resolve } from "path";
+import { join } from "path";
 import { tmpdir } from "os";
 import { ERR_WINDOWS_FAILED_TO_INSTALL_NVDA } from "../errors";
 


### PR DESCRIPTION
The "Do Not Disturb" script is intermittently not working on `macos-12` agent. This is an attempt to resolve.

See https://github.com/actions/runner-images/issues/6804 for details.