### PR TITLE
[#8] MacOS 12 DND Issues Still

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,12 @@ jobs:
       matrix:
         os:
           [
-            macos-11,
+            # macos-11,
             macos-12,
-            macos-latest,
-            windows-2019,
-            windows-2022,
-            windows-latest,
+            # macos-latest,
+            # windows-2019,
+            # windows-2022,
+            # windows-latest,
           ]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,12 @@ jobs:
       matrix:
         os:
           [
-            # macos-11,
+            macos-11,
             macos-12,
-            # macos-latest,
-            # windows-2019,
-            # windows-2022,
-            # windows-latest,
+            macos-latest,
+            windows-2019,
+            windows-2022,
+            windows-latest,
           ]
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 lib
 .DS_Store
 coverage
+recordings

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guidepup/setup",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Setup your environment for screen-reader automation.",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/macOS/enableDoNotDisturb.ts
+++ b/src/macOS/enableDoNotDisturb.ts
@@ -13,11 +13,7 @@ killall usernoted && killall ControlCenter
 const enableFocusModeAppleScript = `
 set timeoutSeconds to 5.0
 
-set openSystemPreferences to "tell application \\"System Preferences\\" to activate"
-
-set clickNotificationAndFocusButton to "click UI Element 1 of scroll area 1 of window \\"System Preferences\\" of application process \\"System Preferences\\""
-
-set clickFocusTab to "click radio button \\"Focus\\" of tab group 1 of window \\"Notifications & Focus\\" of application process \\"System Preferences\\""
+set openPreferences to "do shell script \\"open 'x-apple.systempreferences:com.apple.preference.notifications?focus'\\""
 
 set enableDoNotDisturb to "
 set doNotDisturbToggle to checkbox 1 of group 1 of tab group 1 of window \\"Notifications & Focus\\" of application process \\"System Preferences\\"
@@ -28,9 +24,7 @@ end tell"
 
 set closeSystemPreferences to "tell application \\"System Preferences\\" to quit"
 
-my withTimeout(openSystemPreferences, timeoutSeconds)
-my withTimeout(clickNotificationAndFocusButton, timeoutSeconds)
-my withTimeout(clickFocusTab, timeoutSeconds)
+my withTimeout(openPreferences, timeoutSeconds)
 my withTimeout(enableDoNotDisturb, timeoutSeconds)
 my withTimeout(closeSystemPreferences, timeoutSeconds)
 `;

--- a/src/macOS/enableDoNotDisturb.ts
+++ b/src/macOS/enableDoNotDisturb.ts
@@ -15,7 +15,7 @@ set timeoutSeconds to 5.0
 
 set openSystemPreferences to "tell application \\"System Preferences\\" to activate"
 
-set clickNotificationAndFocusButton to "click UI Element 8 of scroll area 1 of window \\"System Preferences\\" of application process \\"System Preferences\\""
+set clickNotificationAndFocusButton to "click UI Element 9 of scroll area 1 of window \\"System Preferences\\" of application process \\"System Preferences\\""
 
 set clickFocusTab to "click radio button \\"Focus\\" of tab group 1 of window \\"Notifications & Focus\\" of application process \\"System Preferences\\""
 

--- a/src/macOS/enableDoNotDisturb.ts
+++ b/src/macOS/enableDoNotDisturb.ts
@@ -15,7 +15,7 @@ set timeoutSeconds to 5.0
 
 set openSystemPreferences to "tell application \\"System Preferences\\" to activate"
 
-set clickNotificationAndFocusButton to "click UI Element 9 of scroll area 1 of window \\"System Preferences\\" of application process \\"System Preferences\\""
+set clickNotificationAndFocusButton to "click UI Element 1 of scroll area 1 of window \\"System Preferences\\" of application process \\"System Preferences\\""
 
 set clickFocusTab to "click radio button \\"Focus\\" of tab group 1 of window \\"Notifications & Focus\\" of application process \\"System Preferences\\""
 


### PR DESCRIPTION
Fixes #8 

No longer rely on AppleScript to drive navigating to the Notifications & Focus pane as this is very unreliably on MacOS 12, instead open directly using:

```bash
open 'x-apple.systempreferences:com.apple.preference.notifications?focus'
```