### PR TITLE
[#8][#10] Add more browsers and GitLab shells to TCC.db permissions

### DIFF
--- a/src/macOS/setup.ts
+++ b/src/macOS/setup.ts
@@ -17,6 +17,14 @@ const isCi = process.argv.includes("--ci");
 const isRecorded = process.argv.includes("--record");
 
 export async function setup(): Promise<void> {
+  try {
+    updateTccDb();
+  } catch (e) {
+    if (isCi) {
+      throw e;
+    }
+  }
+
   const stopRecording = isRecorded
     ? record(`./recordings/macos-setup-${+new Date()}.mov`)
     : () => null;
@@ -26,14 +34,6 @@ export async function setup(): Promise<void> {
     enableAppleScriptControlSystemDefaults();
     disableSplashScreenSystemDefaults();
     disableDictationInputAutoEnable();
-
-    try {
-      updateTccDb();
-    } catch (e) {
-      if (isCi) {
-        throw e;
-      }
-    }
 
     if (isCi) {
       await enableDoNotDisturb();

--- a/src/macOS/updateTccDb.ts
+++ b/src/macOS/updateTccDb.ts
@@ -3,62 +3,155 @@ import { ERR_MACOS_UNABLE_TO_WRITE_USER_TCC_DB } from "../errors";
 
 const epoch = +Date.now();
 
+/**
+ * See https://www.rainforestqa.com/blog/macos-tcc-db-deep-dive for details on TCC.db entries.
+ */
 const entries: string[] = [
   // Permit Sending Keystrokes
   `'kTCCServicePostEvent','/usr/sbin/sshd',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
   `'kTCCServicePostEvent','/bin/bash',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+  `'kTCCServicePostEvent','/bin/zsh',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
   `'kTCCServicePostEvent','com.apple.Terminal',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
   `'kTCCServicePostEvent','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+  `'kTCCServicePostEvent','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
   // Permit Control Of Device
   `'kTCCServiceAccessibility','/usr/sbin/sshd',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
   `'kTCCServiceAccessibility','/bin/bash',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+  `'kTCCServiceAccessibility','/bin/zsh',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
   `'kTCCServiceAccessibility','com.apple.Terminal',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
   `'kTCCServiceAccessibility','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  // Permit Control Of System Events
-  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
-  // Permit Control Of VoiceOver
-  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
-  // Permit Control Of VoiceOver Utility
-  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
-  // Permit Control Of Finder
-  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
-  // Permit Control Of Safari
-  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
-  // Permit Control Of Playwright
-  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
+  `'kTCCServiceAccessibility','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+  // Permit Full Disk Access
+  `'kTCCServiceSystemPolicyAllFiles','/usr/sbin/sshd',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+  `'kTCCServiceSystemPolicyAllFiles','/bin/bash',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+  `'kTCCServiceSystemPolicyAllFiles','/bin/zsh',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+  `'kTCCServiceSystemPolicyAllFiles','com.apple.Terminal',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+  `'kTCCServiceSystemPolicyAllFiles','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+  `'kTCCServiceSystemPolicyAllFiles','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
   // Permit Access To Microphone
   `'kTCCServiceMicrophone','/usr/sbin/sshd',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,${epoch}`,
   `'kTCCServiceMicrophone','/bin/bash',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,${epoch}`,
+  `'kTCCServiceMicrophone','/bin/zsh',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,${epoch}`,
   `'kTCCServiceMicrophone','com.apple.Terminal',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,${epoch}`,
   `'kTCCServiceMicrophone','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,${epoch}`,
+  `'kTCCServiceMicrophone','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
   // Permit Capture Of System Display
   `'kTCCServiceScreenCapture','/usr/sbin/sshd',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
   `'kTCCServiceScreenCapture','/bin/bash',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+  `'kTCCServiceScreenCapture','/bin/zsh',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
   `'kTCCServiceScreenCapture','com.apple.Terminal',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
   `'kTCCServiceScreenCapture','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+  `'kTCCServiceScreenCapture','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
   // Permit VoiceOver Access To Location
   `'kTCCServiceLiverpool','com.apple.VoiceOverUtility',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
   `'kTCCServiceLiverpool','com.apple.VoiceOver',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
   // Permit VoiceOver Access To Bluetooth
   `'kTCCServiceBluetoothAlways','com.apple.VoiceOver',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+  // Permit Control Of System Events
+  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
+  // Permit Control Of VoiceOver
+  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
+  // Permit Control Of VoiceOver Utility
+  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
+  // Permit Control Of Finder
+  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
+  // Permit Control Of Safari
+  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
+  // Permit Control Of Firefox
+  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'org.mozilla.firefox',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'org.mozilla.firefox',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'org.mozilla.firefox',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'org.mozilla.firefox',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'org.mozilla.firefox',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'org.mozilla.firefox',NULL,NULL,${epoch}`,
+  // Permit Control Of Firefox Nightly And Playwright Firefox Nightly
+  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'org.mozilla.nightly',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'org.mozilla.nightly',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'org.mozilla.nightly',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'org.mozilla.nightly',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'org.mozilla.nightly',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'org.mozilla.nightly',NULL,NULL,${epoch}`,
+  // Permit Control Of Opera
+  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.operasoftware.Opera',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.operasoftware.Opera',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.operasoftware.Opera',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.operasoftware.Opera',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.operasoftware.Opera',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'com.operasoftware.Opera',NULL,NULL,${epoch}`,
+  // Permit Control Of Google Chrome
+  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.google.Chrome',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.google.Chrome',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.google.Chrome',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.google.Chrome',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.google.Chrome',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'com.google.Chrome',NULL,NULL,${epoch}`,
+  // Permit Control Of Google Chrome Beta
+  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.google.Chrome.beta',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.google.Chrome.beta',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.google.Chrome.beta',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.google.Chrome.beta',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.google.Chrome.beta',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'com.google.Chrome.beta',NULL,NULL,${epoch}`,
+  // Permit Control Of Chromium
+  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'org.chromium.Chromium',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'org.chromium.Chromium',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'org.chromium.Chromium',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'org.chromium.Chromium',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'org.chromium.Chromium',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'org.chromium.Chromium',NULL,NULL,${epoch}`,
+  // Permit Control Of Microsoft Edge
+  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac',NULL,NULL,${epoch}`,
+  // Permit Control Of Microsoft Edge Beta
+  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Beta',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Beta',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Beta',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Beta',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Beta',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Beta',NULL,NULL,${epoch}`,
+  // Permit Control Of Microsoft Edge Dev
+  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Dev',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Dev',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Dev',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Dev',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Dev',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Dev',NULL,NULL,${epoch}`,
+  // Permit Control Of Playwright WebKit
+  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
+  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
 ];
 
 const path = "$HOME/Library/Application Support/com.apple.TCC/TCC.db";

--- a/src/macOS/updateTccDb.ts
+++ b/src/macOS/updateTccDb.ts
@@ -3,161 +3,171 @@ import { ERR_MACOS_UNABLE_TO_WRITE_USER_TCC_DB } from "../errors";
 
 const epoch = +Date.now();
 
-/**
- * See https://www.rainforestqa.com/blog/macos-tcc-db-deep-dive for details on TCC.db entries.
- */
-const entries: string[] = [
-  // Permit Sending Keystrokes
-  `'kTCCServicePostEvent','/usr/sbin/sshd',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  `'kTCCServicePostEvent','/bin/bash',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  `'kTCCServicePostEvent','/bin/zsh',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  `'kTCCServicePostEvent','com.apple.Terminal',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  `'kTCCServicePostEvent','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  `'kTCCServicePostEvent','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  // Permit Control Of Device
-  `'kTCCServiceAccessibility','/usr/sbin/sshd',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  `'kTCCServiceAccessibility','/bin/bash',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  `'kTCCServiceAccessibility','/bin/zsh',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  `'kTCCServiceAccessibility','com.apple.Terminal',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  `'kTCCServiceAccessibility','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  `'kTCCServiceAccessibility','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  // Permit Full Disk Access
-  `'kTCCServiceSystemPolicyAllFiles','/usr/sbin/sshd',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  `'kTCCServiceSystemPolicyAllFiles','/bin/bash',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  `'kTCCServiceSystemPolicyAllFiles','/bin/zsh',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  `'kTCCServiceSystemPolicyAllFiles','com.apple.Terminal',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  `'kTCCServiceSystemPolicyAllFiles','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  `'kTCCServiceSystemPolicyAllFiles','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  // Permit Access To Microphone
-  `'kTCCServiceMicrophone','/usr/sbin/sshd',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,${epoch}`,
-  `'kTCCServiceMicrophone','/bin/bash',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,${epoch}`,
-  `'kTCCServiceMicrophone','/bin/zsh',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,${epoch}`,
-  `'kTCCServiceMicrophone','com.apple.Terminal',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,${epoch}`,
-  `'kTCCServiceMicrophone','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,${epoch}`,
-  `'kTCCServiceMicrophone','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  // Permit Capture Of System Display
-  `'kTCCServiceScreenCapture','/usr/sbin/sshd',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  `'kTCCServiceScreenCapture','/bin/bash',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  `'kTCCServiceScreenCapture','/bin/zsh',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  `'kTCCServiceScreenCapture','com.apple.Terminal',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  `'kTCCServiceScreenCapture','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  `'kTCCServiceScreenCapture','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  // Permit VoiceOver Access To Location
-  `'kTCCServiceLiverpool','com.apple.VoiceOverUtility',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  `'kTCCServiceLiverpool','com.apple.VoiceOver',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  // Permit VoiceOver Access To Bluetooth
-  `'kTCCServiceBluetoothAlways','com.apple.VoiceOver',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
-  // Permit Control Of System Events
-  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
-  // Permit Control Of VoiceOver
-  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
-  // Permit Control Of VoiceOver Utility
-  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
-  // Permit Control Of Finder
-  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
-  // Permit Control Of Safari
-  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
-  // Permit Control Of Firefox
-  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'org.mozilla.firefox',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'org.mozilla.firefox',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'org.mozilla.firefox',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'org.mozilla.firefox',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'org.mozilla.firefox',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'org.mozilla.firefox',NULL,NULL,${epoch}`,
-  // Permit Control Of Firefox Nightly And Playwright Firefox Nightly
-  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'org.mozilla.nightly',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'org.mozilla.nightly',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'org.mozilla.nightly',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'org.mozilla.nightly',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'org.mozilla.nightly',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'org.mozilla.nightly',NULL,NULL,${epoch}`,
-  // Permit Control Of Opera
-  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.operasoftware.Opera',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.operasoftware.Opera',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.operasoftware.Opera',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.operasoftware.Opera',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.operasoftware.Opera',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'com.operasoftware.Opera',NULL,NULL,${epoch}`,
-  // Permit Control Of Google Chrome
-  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.google.Chrome',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.google.Chrome',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.google.Chrome',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.google.Chrome',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.google.Chrome',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'com.google.Chrome',NULL,NULL,${epoch}`,
-  // Permit Control Of Google Chrome Beta
-  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.google.Chrome.beta',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.google.Chrome.beta',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.google.Chrome.beta',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.google.Chrome.beta',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.google.Chrome.beta',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'com.google.Chrome.beta',NULL,NULL,${epoch}`,
-  // Permit Control Of Chromium
-  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'org.chromium.Chromium',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'org.chromium.Chromium',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'org.chromium.Chromium',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'org.chromium.Chromium',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'org.chromium.Chromium',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'org.chromium.Chromium',NULL,NULL,${epoch}`,
-  // Permit Control Of Microsoft Edge
-  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac',NULL,NULL,${epoch}`,
-  // Permit Control Of Microsoft Edge Beta
-  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Beta',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Beta',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Beta',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Beta',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Beta',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Beta',NULL,NULL,${epoch}`,
-  // Permit Control Of Microsoft Edge Dev
-  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Dev',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Dev',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Dev',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Dev',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Dev',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Dev',NULL,NULL,${epoch}`,
-  // Permit Control Of Playwright WebKit
-  `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
-  `'kTCCServiceAppleEvents','/usr/local/bin/gitlab-runner',0,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
-];
+const getEntries = (): string[] => {
+  let gitlabRunnerPath: string;
+
+  try {
+    gitlabRunnerPath = execSync("which gitlab-runner", { encoding: "utf8" }).trim();
+  } catch {
+    gitlabRunnerPath = "/usr/local/bin/gitlab-runner";
+  }
+
+  /**
+   * See https://www.rainforestqa.com/blog/macos-tcc-db-deep-dive for details on TCC.db entries.
+   */
+  return [
+    // Permit Sending Keystrokes
+    `'kTCCServicePostEvent','/usr/sbin/sshd',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServicePostEvent','/bin/bash',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServicePostEvent','/bin/zsh',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServicePostEvent','com.apple.Terminal',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServicePostEvent','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServicePostEvent','${gitlabRunnerPath}',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    // Permit Control Of Device
+    `'kTCCServiceAccessibility','/usr/sbin/sshd',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServiceAccessibility','/bin/bash',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServiceAccessibility','/bin/zsh',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServiceAccessibility','com.apple.Terminal',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServiceAccessibility','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServiceAccessibility','${gitlabRunnerPath}',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    // Permit Full Disk Access
+    `'kTCCServiceSystemPolicyAllFiles','/usr/sbin/sshd',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServiceSystemPolicyAllFiles','/bin/bash',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServiceSystemPolicyAllFiles','/bin/zsh',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServiceSystemPolicyAllFiles','com.apple.Terminal',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServiceSystemPolicyAllFiles','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServiceSystemPolicyAllFiles','${gitlabRunnerPath}',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    // Permit Access To Microphone
+    `'kTCCServiceMicrophone','/usr/sbin/sshd',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,${epoch}`,
+    `'kTCCServiceMicrophone','/bin/bash',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,${epoch}`,
+    `'kTCCServiceMicrophone','/bin/zsh',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,${epoch}`,
+    `'kTCCServiceMicrophone','com.apple.Terminal',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,${epoch}`,
+    `'kTCCServiceMicrophone','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,${epoch}`,
+    `'kTCCServiceMicrophone','${gitlabRunnerPath}',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    // Permit Capture Of System Display
+    `'kTCCServiceScreenCapture','/usr/sbin/sshd',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServiceScreenCapture','/bin/bash',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServiceScreenCapture','/bin/zsh',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServiceScreenCapture','com.apple.Terminal',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServiceScreenCapture','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServiceScreenCapture','${gitlabRunnerPath}',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    // Permit VoiceOver Access To Location
+    `'kTCCServiceLiverpool','com.apple.VoiceOverUtility',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServiceLiverpool','com.apple.VoiceOver',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    // Permit VoiceOver Access To Bluetooth
+    `'kTCCServiceBluetoothAlways','com.apple.VoiceOver',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    // Permit Control Of System Events
+    `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${gitlabRunnerPath}',0,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
+    // Permit Control Of VoiceOver
+    `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${gitlabRunnerPath}',0,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
+    // Permit Control Of VoiceOver Utility
+    `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${gitlabRunnerPath}',0,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
+    // Permit Control Of Finder
+    `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${gitlabRunnerPath}',0,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
+    // Permit Control Of Safari
+    `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${gitlabRunnerPath}',0,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
+    // Permit Control Of Firefox
+    `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'org.mozilla.firefox',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'org.mozilla.firefox',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'org.mozilla.firefox',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'org.mozilla.firefox',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'org.mozilla.firefox',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${gitlabRunnerPath}',0,2,3,1,NULL,NULL,0,'org.mozilla.firefox',NULL,NULL,${epoch}`,
+    // Permit Control Of Firefox Nightly And Playwright Firefox Nightly
+    `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'org.mozilla.nightly',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'org.mozilla.nightly',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'org.mozilla.nightly',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'org.mozilla.nightly',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'org.mozilla.nightly',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${gitlabRunnerPath}',0,2,3,1,NULL,NULL,0,'org.mozilla.nightly',NULL,NULL,${epoch}`,
+    // Permit Control Of Opera
+    `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.operasoftware.Opera',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.operasoftware.Opera',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.operasoftware.Opera',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.operasoftware.Opera',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.operasoftware.Opera',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${gitlabRunnerPath}',0,2,3,1,NULL,NULL,0,'com.operasoftware.Opera',NULL,NULL,${epoch}`,
+    // Permit Control Of Google Chrome
+    `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.google.Chrome',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.google.Chrome',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.google.Chrome',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.google.Chrome',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.google.Chrome',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${gitlabRunnerPath}',0,2,3,1,NULL,NULL,0,'com.google.Chrome',NULL,NULL,${epoch}`,
+    // Permit Control Of Google Chrome Beta
+    `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.google.Chrome.beta',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.google.Chrome.beta',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.google.Chrome.beta',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.google.Chrome.beta',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.google.Chrome.beta',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${gitlabRunnerPath}',0,2,3,1,NULL,NULL,0,'com.google.Chrome.beta',NULL,NULL,${epoch}`,
+    // Permit Control Of Chromium
+    `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'org.chromium.Chromium',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'org.chromium.Chromium',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'org.chromium.Chromium',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'org.chromium.Chromium',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'org.chromium.Chromium',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${gitlabRunnerPath}',0,2,3,1,NULL,NULL,0,'org.chromium.Chromium',NULL,NULL,${epoch}`,
+    // Permit Control Of Microsoft Edge
+    `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${gitlabRunnerPath}',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac',NULL,NULL,${epoch}`,
+    // Permit Control Of Microsoft Edge Beta
+    `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Beta',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Beta',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Beta',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Beta',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Beta',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${gitlabRunnerPath}',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Beta',NULL,NULL,${epoch}`,
+    // Permit Control Of Microsoft Edge Dev
+    `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Dev',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Dev',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Dev',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Dev',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Dev',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${gitlabRunnerPath}',0,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Dev',NULL,NULL,${epoch}`,
+    // Permit Control Of Playwright WebKit
+    `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/bin/zsh',1,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','com.apple.Terminal',0,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',0,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${gitlabRunnerPath}',0,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
+  ];
+};
 
 const path = "$HOME/Library/Application Support/com.apple.TCC/TCC.db";
 
 export function updateTccDb(): void {
-  for (const values of entries) {
+  for (const values of getEntries()) {
     const query = `INSERT OR IGNORE INTO access VALUES(${values});`;
 
     try {


### PR DESCRIPTION
Fixes #8 
Fixes #10 

In order to allow automation from the GitLab runner, and automation of all Playwright browsers, more entries are needed in the `TCC.db`.

Because GitLab doesn't have any entries (afaik) we need to move the update to before the screen-recording logic otherwise that will result in a UI prompt and not work.