### PR TITLE
Allowed setup script to run on Darwin 22+ without enabling DND

### DIFF
--- a/src/macOS/enableDoNotDisturb.ts
+++ b/src/macOS/enableDoNotDisturb.ts
@@ -38,11 +38,17 @@ export async function enableDoNotDisturb() {
   try {
     if (platformMajor <= 20) {
       await promisify(exec)(enableFocusModeShellscript);
-    } else {
+    } else if (platformMajor === 21) {
       // From MacOS 12 Monterey (Darwin 21) there is no known way to enable DND via system defaults
       await retryOnError(() => runAppleScript(enableFocusModeAppleScript));
+    } else {
+      // From MacOS 13 Ventura (Darwin 22) it seems that even AppleScript is not working anymore
+      // As far as enabling DND increases testing stability it's better to be able test on newer MacOS versions than to not be able to do it without DND
+      return;
     }
   } catch (e) {
-    throw new Error(`${ERR_MACOS_FAILED_TO_ENABLE_DO_NOT_DISTURB}\n\n${e.message}`);
+    throw new Error(
+      `${ERR_MACOS_FAILED_TO_ENABLE_DO_NOT_DISTURB}\n\n${e.message}`
+    );
   }
 }


### PR DESCRIPTION
Enabling Do not disturb mode was added to increase VO tests stability. 
It became very difficult to enable DnD (via Focus mode) on macOS Monterey
But it worked.

From macOs Ventura it became almost impossible.

Because having  DnD while running tests is nice but not critical I have disabled it on newer macOs until we find some suitable way to enable DnD on it.