### PR TITLE
feat: support MacOS Sonoma

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11, macos-12, macos-13, windows-2019, windows-2022]
+        os: [macos-11, macos-12, macos-13, macos-14, windows-2019, windows-2022]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11, macos-12, macos-13, macos-14, windows-2019, windows-2022]
+        os: [macos-11, macos-12, macos-13, windows-2019, windows-2022]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -21,6 +21,24 @@ jobs:
           node-version: 20
       - run: yarn install --frozen-lockfile
       - run: yarn ci
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: artifacts
+          path: |
+            **/recordings/**/*
+  test-ignore-tcc-db:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-14]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: yarn install --frozen-lockfile
+      - run: yarn ci:ignore-tcc-db
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![MacOS Big Sur Support](https://img.shields.io/badge/macos-Big_Sur-blue.svg?logo=apple)](https://apps.apple.com/id/app/macos-big-sur/id1526878132)
 [![MacOS Monetary Support](https://img.shields.io/badge/macos-Monetary-blue.svg?logo=apple)](https://apps.apple.com/us/app/macos-monterey/id1576738294)
 [![MacOS Ventura Support](https://img.shields.io/badge/macos-Ventura-blue.svg?logo=apple)](https://apps.apple.com/us/app/macos-ventura/id1638787999)
+[![MacOS Sonoma Support](https://img.shields.io/badge/macos-Somona-blue.svg?logo=apple)](https://apps.apple.com/us/app/macos-sonoma/id6450717509)
 [![Windows 10 Support](https://img.shields.io/badge/windows-10-blue.svg?logo=windows10)](https://www.microsoft.com/en-gb/software-download/windows10ISO)
 [![Windows Server 2019 Support](https://img.shields.io/badge/windows_server-2019-blue.svg?logo=windows)](https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2019)
 [![Windows Server 2022 Support](https://img.shields.io/badge/windows_server-2022-blue.svg?logo=windows)](https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2022)

--- a/README.md
+++ b/README.md
@@ -42,11 +42,25 @@ If you are using GitHub Actions, check out the dedicated [`guidepup/setup-action
 
 If you are running this command locally, you might find it prompts you to pass in credentials so that it can using UI automation to change a checkbox value which enables the automation of VoiceOver. If you are uncomfortable with providing your credentials you can manually achieve these steps by following the [manual VoiceOver setup documentation](https://www.guidepup.dev/docs/guides/manual-voiceover-setup).
 
+#### CI
+
 If you are running this command in CI/CD, it is recommended to add the `--ci` flag to prevent interactive prompts:
 
 ```console
 npx @guidepup/setup --ci
 ```
+
+#### Ignore TCC.db Updates
+
+If updating the TCC.db is not possible (due to SIP) or required you can skip the database update step by using the `--ignore-tcc-db` flag:
+
+```console
+npx @guidepup/setup --ignore-tcc-db
+```
+
+> Note: If the necessary permissions have not been granted by other means, using this flag may result in your environment not being setup for reliable screen reader automation.
+
+#### Recording
 
 If you are encountering errors in CI for MacOS you can pass a `--record` flag to the command which will output a screen-recording of the setup to a `./recordings/` directory:
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build": "yarn clean && yarn compile",
     "ci": "yarn clean && yarn lint && yarn build && yarn resolutionFix && yarn start --ci --record",
     "ci:nvda-install-dir": "yarn clean && yarn lint && yarn build && yarn resolutionFix && yarn start --ci --record --nvda-install-dir %userprofile%\\nvda",
+    "ci:ignore-tcc-db": "yarn clean && yarn lint && yarn build && yarn resolutionFix && yarn start --ci --record --ignore-tcc-db",
     "clean": "rimraf lib",
     "compile": "tsc",
     "dev": "ts-node ./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guidepup/setup",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Setup your environment for screen-reader automation.",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 
 export const logInfo = console.info.bind(console);
+export const logWarn = console.warn.bind(console);
 export const logError = console.error.bind(console);
 
 export function handleComplete(): never {
@@ -9,6 +10,27 @@ export function handleComplete(): never {
   logInfo("");
 
   process.exit(0);
+}
+
+export function handleWarning(err: Error): void {
+  let message = err.message;
+
+  if (err.name) {
+    message = `${err.name}: ${message}`;
+  }
+
+  logWarn("");
+  logWarn(chalk.bold(chalk.yellow(`[!] ${chalk.bold(message.toString())}`)));
+  logWarn("");
+  logWarn("Unable to complete environment setup");
+  logWarn("");
+  logWarn(
+    chalk.dim(
+      "Please raise new issues at: " +
+        chalk.underline("https://github.com/guidepup/setup/issues")
+    )
+  );
+  logWarn("");
 }
 
 export function handleError(err: Error): never {

--- a/src/macOS/setup.ts
+++ b/src/macOS/setup.ts
@@ -16,21 +16,24 @@ import { enableDoNotDisturb } from "./enableDoNotDisturb";
 import { enabledDbFile } from "./isAppleScriptControlEnabled/enabledDbFile";
 
 const isCi = process.argv.includes("--ci");
+const ignoreTccDb = process.argv.includes("--ignore-tcc-db");
 const isRecorded = process.argv.includes("--record");
 
 export async function setup(): Promise<void> {
-  try {
-    updateTccDb(USER_PATH);
-  } catch (e) {
-    if (isCi) {
-      throw e;
+  if (!ignoreTccDb) {
+    try {
+      updateTccDb(USER_PATH);
+    } catch (e) {
+      if (isCi) {
+        throw e;
+      }
     }
-  }
 
-  try {
-    updateTccDb(SYSTEM_PATH);
-  } catch {
-    // Swallow error - most CI don't allow system configuration
+    try {
+      updateTccDb(SYSTEM_PATH);
+    } catch {
+      // Swallow error - most CI don't allow system configuration
+    }
   }
 
   const osName = platform();


### PR DESCRIPTION
## Details

Support for MacOS Sonoma.

Also introduces a new `--ignore-tcc-db` flag for GH Actions where updating the TCC.db is not possible on the `macos-14` agents.

## CheckList

- [ ] Has been tested (where required).
