### PR TITLE
fix: sonoma expects extra values in tcc.db

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11, macos-12, macos-13, windows-2019, windows-2022]
+        os: [macos-11, macos-12, macos-13, macos-14, windows-2019, windows-2022]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/src/macOS/updateTccDb.ts
+++ b/src/macOS/updateTccDb.ts
@@ -214,7 +214,7 @@ export const SYSTEM_PATH = "/Library/Application Support/com.apple.TCC/TCC.db";
 export function updateTccDb(path: string): void {
   for (const values of getEntries()) {
     const osRelease = release();
-    const isSonomaOrNewer = parseInt(osRelease.split(".").at(0)) >= 22;
+    const isSonomaOrNewer = parseInt(osRelease.split(".").at(0)) >= 23;
     const query = `INSERT OR IGNORE INTO access VALUES(${values}${
       isSonomaOrNewer ? `,NULL,NULL,'UNUSED',${epoch}` : ""
     });`;

--- a/src/macOS/updateTccDb.ts
+++ b/src/macOS/updateTccDb.ts
@@ -1,3 +1,4 @@
+import { release } from "os";
 import { execSync } from "child_process";
 import { ERR_MACOS_UNABLE_TO_WRITE_USER_TCC_DB } from "../errors";
 
@@ -206,12 +207,17 @@ const getEntries = (): string[] => {
   ];
 };
 
-export const USER_PATH = "$HOME/Library/Application Support/com.apple.TCC/TCC.db";
+export const USER_PATH =
+  "$HOME/Library/Application Support/com.apple.TCC/TCC.db";
 export const SYSTEM_PATH = "/Library/Application Support/com.apple.TCC/TCC.db";
 
 export function updateTccDb(path: string): void {
   for (const values of getEntries()) {
-    const query = `INSERT OR IGNORE INTO access VALUES(${values});`;
+    const osRelease = release();
+    const isSonomaOrNewer = parseInt(osRelease.split(".").at(0)) >= 22;
+    const query = `INSERT OR IGNORE INTO access VALUES(${values}${
+      isSonomaOrNewer ? `,NULL,NULL,'UNUSED',${epoch}` : ""
+    });`;
 
     try {
       execSync(`sqlite3 "${path}" "${query}" >/dev/null 2>&1`);


### PR DESCRIPTION
## Details

See note on GH actions runner images repo that indicates Sonoma expects extra values in it's TCC.db: https://github.com/actions/runner-images/blob/main/images/macos/scripts/build/configure-tccdb-macos.sh#L36

## CheckList

- [ ] Has been tested (where required).
