### PR TITLE
Feat: adds proxy agent for NVDA installation request

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ If you want to specify the directory that NVDA is installed to you can pass a `-
 npx @guidepup/setup --nvda-install-dir <NVDA_INSTALLATION_DIRECTORY>
 ```
 
+##### Using HTTP / HTTPS Proxy for Installation
+
+If you are using a proxy connection, you must define the proxy URL in an env variable. You can use any of the following variables:
+
+- `HTTPS_PROXY`
+- `https_proxy`
+- `HTTP_PROXY`
+- `http_proxy`
+
 #### Foreground Timeout Lock
 
 Modern versions of Windows have a setting which prevents new application instances launching in front of other applications in quick succession, requiring over 3 minutes between activations before it will actually show the window - in the interim it launches the window minimized.

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@guidepup/guidepup": "^0.22.0",
     "chalk": "^4.0.0",
     "decompress": "^4.2.1",
+    "https-proxy-agent": "^7.0.5",
     "regedit": "5.0.1",
     "semver": "^7.5.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -296,6 +296,13 @@ agent-base@6:
   dependencies:
     debug "4"
 
+agent-base@^7.0.2:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.1.tgz#bdbded7dfb096b751a2a087eeeb9664725b2e317"
+  integrity sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==
+  dependencies:
+    debug "^4.3.4"
+
 ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -923,6 +930,14 @@ https-proxy-agent@^5.0.0:
   integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
   dependencies:
     agent-base "6"
+    debug "4"
+
+https-proxy-agent@^7.0.5:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz#9e8b5013873299e11fab6fd548405da2d6c602b2"
+  integrity sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==
+  dependencies:
+    agent-base "^7.0.2"
     debug "4"
 
 ieee754@^1.1.13:


### PR DESCRIPTION
# Issue

No issue found.

## Details

Until now it was not possible to download NVDA on windows when using a proxy.

## CheckList

- [x] Has been tested (where required).
