### PR TITLE
fix: circleci doesn't have permissions (#34)

### DIFF
--- a/src/macOS/updateTccDb.ts
+++ b/src/macOS/updateTccDb.ts
@@ -3,6 +3,7 @@ import { execSync } from "child_process";
 import { ERR_MACOS_UNABLE_TO_WRITE_USER_TCC_DB } from "../errors";
 
 const epoch = +Date.now();
+const circleciRunner = "/private/tmp/.machine-agent";
 
 const getEntries = (): string[] => {
   let gitlabRunnerPath: string;
@@ -28,6 +29,7 @@ const getEntries = (): string[] => {
     `'kTCCServicePostEvent','/usr/local/opt/runner/runprovisioner.sh',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
     `'kTCCServicePostEvent','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
     `'kTCCServicePostEvent','${gitlabRunnerPath}',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServicePostEvent','${circleciRunner}',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
     // Permit Control Of Device
     `'kTCCServiceAccessibility','/usr/sbin/sshd',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
     `'kTCCServiceAccessibility','/bin/bash',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
@@ -37,6 +39,7 @@ const getEntries = (): string[] => {
     `'kTCCServiceAccessibility','/usr/local/opt/runner/runprovisioner.sh',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
     `'kTCCServiceAccessibility','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
     `'kTCCServiceAccessibility','${gitlabRunnerPath}',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServiceAccessibility','${circleciRunner}',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
     // Permit Full Disk Access
     `'kTCCServiceSystemPolicyAllFiles','/usr/sbin/sshd',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
     `'kTCCServiceSystemPolicyAllFiles','/bin/bash',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
@@ -46,6 +49,7 @@ const getEntries = (): string[] => {
     `'kTCCServiceSystemPolicyAllFiles','/usr/local/opt/runner/runprovisioner.sh',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
     `'kTCCServiceSystemPolicyAllFiles','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
     `'kTCCServiceSystemPolicyAllFiles','${gitlabRunnerPath}',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServiceSystemPolicyAllFiles','${circleciRunner}',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
     // Permit Access To Microphone
     `'kTCCServiceMicrophone','/usr/sbin/sshd',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,${epoch}`,
     `'kTCCServiceMicrophone','/bin/bash',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,${epoch}`,
@@ -55,6 +59,7 @@ const getEntries = (): string[] => {
     `'kTCCServiceMicrophone','/usr/local/opt/runner/runprovisioner.sh',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,${epoch}`,
     `'kTCCServiceMicrophone','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,${epoch}`,
     `'kTCCServiceMicrophone','${gitlabRunnerPath}',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServiceMicrophone','${circleciRunner}',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
     // Permit Capture Of System Display
     `'kTCCServiceScreenCapture','/usr/sbin/sshd',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
     `'kTCCServiceScreenCapture','/bin/bash',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
@@ -64,6 +69,7 @@ const getEntries = (): string[] => {
     `'kTCCServiceScreenCapture','/usr/local/opt/runner/runprovisioner.sh',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
     `'kTCCServiceScreenCapture','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
     `'kTCCServiceScreenCapture','${gitlabRunnerPath}',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
+    `'kTCCServiceScreenCapture','${circleciRunner}',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
     // Permit VoiceOver Access To Location
     `'kTCCServiceLiverpool','com.apple.VoiceOverUtility',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
     `'kTCCServiceLiverpool','com.apple.VoiceOver',0,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,${epoch}`,
@@ -78,6 +84,7 @@ const getEntries = (): string[] => {
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',1,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','${gitlabRunnerPath}',1,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${circleciRunner}',1,2,3,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,${epoch}`,
     // Permit Control Of VoiceOver
     `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
@@ -87,6 +94,7 @@ const getEntries = (): string[] => {
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','${gitlabRunnerPath}',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${circleciRunner}',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOver',NULL,NULL,${epoch}`,
     // Permit Control Of VoiceOver Utility
     `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
@@ -96,6 +104,7 @@ const getEntries = (): string[] => {
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','${gitlabRunnerPath}',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${circleciRunner}',1,2,3,1,NULL,NULL,0,'com.apple.VoiceOverUtility',NULL,NULL,${epoch}`,
     // Permit Control Of Finder
     `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
@@ -105,6 +114,7 @@ const getEntries = (): string[] => {
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',1,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','${gitlabRunnerPath}',1,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${circleciRunner}',1,2,3,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,${epoch}`,
     // Permit Control Of Safari
     `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
@@ -114,6 +124,7 @@ const getEntries = (): string[] => {
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',1,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','${gitlabRunnerPath}',1,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${circleciRunner}',1,2,3,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,${epoch}`,
     // Permit Control Of Firefox
     `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'org.mozilla.firefox',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'org.mozilla.firefox',NULL,NULL,${epoch}`,
@@ -123,6 +134,7 @@ const getEntries = (): string[] => {
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',1,2,3,1,NULL,NULL,0,'org.mozilla.firefox',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'org.mozilla.firefox',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','${gitlabRunnerPath}',1,2,3,1,NULL,NULL,0,'org.mozilla.firefox',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${circleciRunner}',1,2,3,1,NULL,NULL,0,'org.mozilla.firefox',NULL,NULL,${epoch}`,
     // Permit Control Of Firefox Nightly And Playwright Firefox Nightly
     `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'org.mozilla.nightly',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'org.mozilla.nightly',NULL,NULL,${epoch}`,
@@ -132,6 +144,7 @@ const getEntries = (): string[] => {
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',1,2,3,1,NULL,NULL,0,'org.mozilla.nightly',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'org.mozilla.nightly',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','${gitlabRunnerPath}',1,2,3,1,NULL,NULL,0,'org.mozilla.nightly',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${circleciRunner}',1,2,3,1,NULL,NULL,0,'org.mozilla.nightly',NULL,NULL,${epoch}`,
     // Permit Control Of Opera
     `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.operasoftware.Opera',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.operasoftware.Opera',NULL,NULL,${epoch}`,
@@ -141,6 +154,7 @@ const getEntries = (): string[] => {
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',1,2,3,1,NULL,NULL,0,'com.operasoftware.Opera',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.operasoftware.Opera',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','${gitlabRunnerPath}',1,2,3,1,NULL,NULL,0,'com.operasoftware.Opera',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${circleciRunner}',1,2,3,1,NULL,NULL,0,'com.operasoftware.Opera',NULL,NULL,${epoch}`,
     // Permit Control Of Google Chrome
     `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.google.Chrome',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.google.Chrome',NULL,NULL,${epoch}`,
@@ -150,6 +164,7 @@ const getEntries = (): string[] => {
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',1,2,3,1,NULL,NULL,0,'com.google.Chrome',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.google.Chrome',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','${gitlabRunnerPath}',1,2,3,1,NULL,NULL,0,'com.google.Chrome',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${circleciRunner}',1,2,3,1,NULL,NULL,0,'com.google.Chrome',NULL,NULL,${epoch}`,
     // Permit Control Of Google Chrome Beta
     `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.google.Chrome.beta',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.google.Chrome.beta',NULL,NULL,${epoch}`,
@@ -159,6 +174,7 @@ const getEntries = (): string[] => {
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',1,2,3,1,NULL,NULL,0,'com.google.Chrome.beta',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.google.Chrome.beta',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','${gitlabRunnerPath}',1,2,3,1,NULL,NULL,0,'com.google.Chrome.beta',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${circleciRunner}',1,2,3,1,NULL,NULL,0,'com.google.Chrome.beta',NULL,NULL,${epoch}`,
     // Permit Control Of Chromium
     `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'org.chromium.Chromium',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'org.chromium.Chromium',NULL,NULL,${epoch}`,
@@ -168,6 +184,7 @@ const getEntries = (): string[] => {
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',1,2,3,1,NULL,NULL,0,'org.chromium.Chromium',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'org.chromium.Chromium',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','${gitlabRunnerPath}',1,2,3,1,NULL,NULL,0,'org.chromium.Chromium',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${circleciRunner}',1,2,3,1,NULL,NULL,0,'org.chromium.Chromium',NULL,NULL,${epoch}`,
     // Permit Control Of Microsoft Edge
     `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac',NULL,NULL,${epoch}`,
@@ -177,6 +194,7 @@ const getEntries = (): string[] => {
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','${gitlabRunnerPath}',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${circleciRunner}',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac',NULL,NULL,${epoch}`,
     // Permit Control Of Microsoft Edge Beta
     `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Beta',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Beta',NULL,NULL,${epoch}`,
@@ -186,6 +204,7 @@ const getEntries = (): string[] => {
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Beta',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Beta',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','${gitlabRunnerPath}',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Beta',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${circleciRunner}',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Beta',NULL,NULL,${epoch}`,
     // Permit Control Of Microsoft Edge Dev
     `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Dev',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Dev',NULL,NULL,${epoch}`,
@@ -195,6 +214,7 @@ const getEntries = (): string[] => {
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Dev',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Dev',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','${gitlabRunnerPath}',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Dev',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${circleciRunner}',1,2,3,1,NULL,NULL,0,'com.microsoft.edgemac.Dev',NULL,NULL,${epoch}`,
     // Permit Control Of Playwright WebKit
     `'kTCCServiceAppleEvents','/usr/sbin/sshd',1,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/bin/bash',1,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
@@ -204,6 +224,7 @@ const getEntries = (): string[] => {
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',1,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
     `'kTCCServiceAppleEvents','${gitlabRunnerPath}',1,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
+    `'kTCCServiceAppleEvents','${circleciRunner}',1,2,3,1,NULL,NULL,0,'org.webkit.Playwright',NULL,NULL,${epoch}`,
   ];
 };
 


### PR DESCRIPTION
# Issue

Fixes #34

## Details

CircleCI runs a process called '.machine-agent' which needs permissions to do all the things required for the test.

I created a variable to make it clearer what this path is for. The macos orb[1] has an 'add-permission' command but it's hard coded to expect a bundle id, not a path to an executable so we can't use it.

Some permissions can be got from

      - macos/add-uitest-permissions
      - macos/add-safari-permissions
      - macos/add-voiceover-permissions

but not enough for a VoiceOver test

[1]: https://circleci.com/developer/orbs/orb/circleci/macos

## CheckList

- [ ] Has been tested (where required).
