### PR TITLE
feat: add macos-15 runner to matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, macos-13, macos-14, windows-2019, windows-2022]
+        os: [macos-12, macos-13, macos-14, macos-15, windows-2019, windows-2022]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, macos-13, macos-14, macos-15, windows-2019, windows-2022]
+        os: [macos-13, macos-14, macos-15, windows-2019, windows-2022]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
# Issue

No issue

## Details

Adds macos-15 runner and removes the deprecated macos-12 runner for CI.

Follow-up needed to update docs / support matrix.

## CheckList

- [ ] Has been tested (where required).
