### PR TITLE
fix: swallow TCC.db SQL non-fatal warnings and log user friendly message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guidepup/setup",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "CLI for configuring environments and install screen reader assets for Guidepup.",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/commands/setup/macOS/setup.ts
+++ b/src/commands/setup/macOS/setup.ts
@@ -37,7 +37,7 @@ export async function setup({
       } else {
         handleNote(
           "Unable to configure automation permissions",
-          "This can be expected when running Guidepup locally if macOS does not grant the required permissions automatically.\nPlease accept any system dialogs requesting automation permissions while using Guidepup.\nIf you are running Guidepup in CI, use the `--ci` option to skip interactive permission setup.\nAlternatively, please refer to https://www.guidepup.dev/docs/guides/manual-voiceover-setup for instructions on manually configuring VoiceOver permissions.",
+          "This can be expected when running the Guidepup setup locally if macOS does not grant the required permissions automatically.\nPlease accept any system dialogs requesting automation permissions while using Guidepup.\nIf you are running Guidepup in CI, use the `--ci` option to skip interactive permission setup.\nAlternatively, please refer to https://www.guidepup.dev/docs/guides/manual-voiceover-setup for instructions on manually configuring VoiceOver permissions.",
         );
       }
     }

--- a/src/commands/setup/macOS/setup.ts
+++ b/src/commands/setup/macOS/setup.ts
@@ -7,7 +7,11 @@ import { isSipEnabled } from "./isSipEnabled";
 import { writeDatabaseFile } from "./writeDatabaseFile";
 import { SYSTEM_PATH, USER_PATH, updateTccDb } from "./updateTccDb";
 import { isAppleScriptControlEnabled } from "./isAppleScriptControlEnabled";
-import { handleSetupManualRequired, handleWarning } from "../../../logging";
+import {
+  handleNote,
+  handleSetupManualRequired,
+  handleWarning,
+} from "../../../logging";
 import { ERR_SETUP_MACOS_REQUIRES_MANUAL_USER_INTERACTION } from "../../../errors";
 import { enableDoNotDisturb } from "./enableDoNotDisturb";
 import { enabledDbFile } from "./isAppleScriptControlEnabled/enabledDbFile";
@@ -30,6 +34,11 @@ export async function setup({
     } catch (e) {
       if (ci) {
         throw e;
+      } else {
+        handleNote(
+          "Unable to configure automation permissions",
+          "This can be expected when running Guidepup locally if macOS does not grant the required permissions automatically.\nPlease accept any system dialogs requesting automation permissions while using Guidepup.\nIf you are running Guidepup in CI, use the `--ci` option to skip interactive permission setup.\nAlternatively, please refer to https://www.guidepup.dev/docs/guides/manual-voiceover-setup for instructions on manually configuring VoiceOver permissions.",
+        );
       }
     }
 
@@ -40,8 +49,8 @@ export async function setup({
     }
   } else {
     handleWarning(
-      "Ignoring TCC database updates",
-      "If the necessary permissions have not been granted by other means, using this flag may result in your environment not being set up for reliable screen reader automation.",
+      "Skipping automation permission setup",
+      "If the necessary permissions have not been granted by other means, this may result in an environment that is not reliably configured for screen reader automation.\n\nPlease refer to https://www.guidepup.dev/docs/guides/manual-voiceover-setup for instructions on manually configuring VoiceOver permissions.",
     );
   }
 

--- a/src/commands/setup/macOS/updateTccDb.ts
+++ b/src/commands/setup/macOS/updateTccDb.ts
@@ -194,7 +194,7 @@ export function updateTccDb(path: string): void {
     });`;
 
     try {
-      execSync(`sqlite3 "${path}" "${query}"`, {
+      execSync(`sqlite3 "${path}" "${query}" >/dev/null 2>&1`, {
         encoding: "utf8",
       });
     } catch (cause) {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -12,7 +12,7 @@ export const ERR_SETUP_MACOS_UNABLE_TO_VERIFY_SIP =
 export const ERR_SETUP_MACOS_UNABLE_TO_WRITE_DATABASE_FILE =
   "Unable to write to the VoiceOver database file\n\nEnsure that SIP is disabled or pass '--macos-ignore-tcc-db' to ignore TCC database updates";
 export const ERR_SETUP_MACOS_UNABLE_TO_WRITE_USER_TCC_DB =
-  "Unable to write to the user TCC database\n\nEnsure that SIP is disabled or pass '--macos-ignore-tcc-db' to ignore TCC database updates";
+  "Unable to write to the user TCC database\n\nEnsure that SIP is disabled for the database, or pass '--macos-ignore-tcc-db' to ignore TCC database updates";
 export const ERR_SETUP_MACOS_REQUIRES_MANUAL_USER_INTERACTION =
   "Unable to setup environment without manual user interaction\n\nEnsure that SIP is disabled or preconfigure your environment with 'Allow VoiceOver to be controlled with AppleScript' enabled";
 export const ERR_SETUP_MACOS_FAILED_TO_ENABLE_DO_NOT_DISTURB =

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -51,6 +51,14 @@ export function handleInfoWithPath(message, urlOrPath) {
   logInfo(`${message} ${chalk.dim(urlOrPath)}`);
 }
 
+export function handleNote(title: string, subtitle: string): void {
+  logWarn("");
+  logWarn(chalk.bold(chalk.blue(`[!] Note: ${chalk.bold(title)}`)));
+  logWarn("");
+  logWarn(subtitle);
+  logError("");
+}
+
 export function handleWarning(title: string, subtitle: string): void {
   logWarn("");
   logWarn(chalk.bold(chalk.yellow(`[!] Warning: ${chalk.bold(title)}`)));

--- a/yarn.lock
+++ b/yarn.lock
@@ -348,24 +348,24 @@ bluebird@~3.7.2:
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 brace-expansion@^1.1.7:
-  version "1.1.12"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz"
-  integrity sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.18.tgz#3ce74d89885136be1535341f8c3d4425c29a5cab"
+  integrity sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 brace-expansion@^2.0.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.2.tgz#0bba2271feb7d458b0d31ad13625aaa4754431e2"
-  integrity sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.4.tgz#589dab11c0018d0366be64cd8bf12c8dbecc8326"
+  integrity sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==
   dependencies:
     balanced-match "^1.0.0"
 
-brace-expansion@^5.0.5:
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.7.tgz#1b0e46965b479dad65af737b4a02790a05498337"
-  integrity sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==
+brace-expansion@^5.0.8:
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.9.tgz#7c72438809b5fa5babf54199a1f1c281a6984fcf"
+  integrity sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==
   dependencies:
     balanced-match "^4.0.2"
 
@@ -944,11 +944,11 @@ micromatch@^4.0.8:
     picomatch "^2.3.1"
 
 minimatch@^10.1.1:
-  version "10.2.5"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
-  integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==
+  version "10.2.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.6.tgz#fd956bbe0b77241e9f15ac5dccb1c638060968ef"
+  integrity sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==
   dependencies:
-    brace-expansion "^5.0.5"
+    brace-expansion "^5.0.8"
 
 minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.5"


### PR DESCRIPTION
# Issue

Fixes #61

## Details

When running `npx @guidepup/setup setup` locally it is generally expected that TCC.db updates will be denied due to SIP (generally a good thing!).

For local development this isn't really a problem because when it comes to running Guidepup you will receive a system dialog prompting for permissions to automate applications (same as you get when using Playwright, or indeed many applications) which you can interact with to manually/JIT provide the required permissions.

Thus swallowing the stdout/stderr warnings that are emitted from the SQL command when it fails.

There is a risk that users will deny those permissions if they aren't aware why the dialog has appeared, so this change also adds a note log to explain the behaviour, linking off to docs for manual steps if preferred (or to rectify a denial of permissions from system prompt).

```console
$ npx @guidepup/setup setup

[!] Note: Unable to configure automation permissions

This can be expected when running the Guidepup setup locally if macOS does not grant the required permissions automatically.
Please accept any system dialogs requesting automation permissions while using Guidepup.
If you are running Guidepup in CI, use the `--ci` option to skip interactive permission setup.
Alternatively, please refer to https://www.guidepup.dev/docs/guides/manual-voiceover-setup for instructions on manually configuring VoiceOver permissions.


Environment setup complete 🎉
```

## CheckList

- [x] Has been tested (where required).
