### PR TITLE
fix: add 5s timeout for acquiring TCC.db lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guidepup/setup",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "description": "CLI for configuring environments and install screen reader assets for Guidepup.",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/commands/setup/macOS/updateTccDb.ts
+++ b/src/commands/setup/macOS/updateTccDb.ts
@@ -1,5 +1,5 @@
 import { release } from "os";
-import { execSync } from "child_process";
+import { execSync, execFileSync } from "child_process";
 import { ERR_SETUP_MACOS_UNABLE_TO_WRITE_USER_TCC_DB } from "../../../errors";
 
 const epoch = Math.floor(Date.now() / 1000);
@@ -186,19 +186,23 @@ export const USER_PATH =
 export const SYSTEM_PATH = "/Library/Application Support/com.apple.TCC/TCC.db";
 
 export function updateTccDb(path: string): void {
+  const osRelease = release();
+  const isSonomaOrNewer = parseInt(osRelease.split(".")[0], 10) >= 23;
+
   for (const values of getEntries()) {
-    const osRelease = release();
-    const isSonomaOrNewer = parseInt(osRelease.split(".").at(0)) >= 23;
-    const query = `INSERT OR IGNORE INTO access VALUES(${values}${
+    const query = `.timeout 5000\nINSERT OR IGNORE INTO access VALUES(${values}${
       isSonomaOrNewer ? `,NULL,NULL,'UNUSED',${epoch}` : ""
     });`;
 
     try {
-      execSync(`sqlite3 "${path}" "${query}" >/dev/null 2>&1`, {
+      execFileSync("sqlite3", [path, query], {
         encoding: "utf8",
+        stdio: "ignore",
       });
     } catch (cause) {
-      throw new Error(ERR_SETUP_MACOS_UNABLE_TO_WRITE_USER_TCC_DB, { cause });
+      throw new Error(ERR_SETUP_MACOS_UNABLE_TO_WRITE_USER_TCC_DB, {
+        cause,
+      });
     }
   }
 }

--- a/src/commands/setup/macOS/updateTccDb.ts
+++ b/src/commands/setup/macOS/updateTccDb.ts
@@ -1,4 +1,4 @@
-import { release } from "os";
+import { homedir, release } from "os";
 import { execSync, execFileSync } from "child_process";
 import { ERR_SETUP_MACOS_UNABLE_TO_WRITE_USER_TCC_DB } from "../../../errors";
 
@@ -181,8 +181,7 @@ const getEntries = (): string[] => {
   ];
 };
 
-export const USER_PATH =
-  "$HOME/Library/Application Support/com.apple.TCC/TCC.db";
+export const USER_PATH = `${homedir()}/Library/Application Support/com.apple.TCC/TCC.db`;
 export const SYSTEM_PATH = "/Library/Application Support/com.apple.TCC/TCC.db";
 
 export function updateTccDb(path: string): void {

--- a/src/commands/setup/macOS/updateTccDb.ts
+++ b/src/commands/setup/macOS/updateTccDb.ts
@@ -190,12 +190,12 @@ export function updateTccDb(path: string): void {
   const isSonomaOrNewer = parseInt(osRelease.split(".")[0], 10) >= 23;
 
   for (const values of getEntries()) {
-    const query = `.timeout 5000\nINSERT OR IGNORE INTO access VALUES(${values}${
+    const query = `INSERT OR IGNORE INTO access VALUES(${values}${
       isSonomaOrNewer ? `,NULL,NULL,'UNUSED',${epoch}` : ""
     });`;
 
     try {
-      execFileSync("sqlite3", [path, query], {
+      execFileSync("sqlite3", [path, ".timeout 5000", query], {
         encoding: "utf8",
         stdio: "ignore",
       });

--- a/src/commands/setup/macOS/updateTccDb.ts
+++ b/src/commands/setup/macOS/updateTccDb.ts
@@ -190,14 +190,13 @@ export function updateTccDb(path: string): void {
   const isSonomaOrNewer = parseInt(osRelease.split(".")[0], 10) >= 23;
 
   for (const values of getEntries()) {
-    const query = `INSERT OR IGNORE INTO access VALUES(${values}${
+    const query = `.timeout 5000\nINSERT OR IGNORE INTO access VALUES(${values}${
       isSonomaOrNewer ? `,NULL,NULL,'UNUSED',${epoch}` : ""
     });`;
 
     try {
-      execFileSync("sqlite3", [path, ".timeout 5000", query], {
+      execFileSync("sqlite3", [path, query], {
         encoding: "utf8",
-        stdio: "ignore",
       });
     } catch (cause) {
       throw new Error(ERR_SETUP_MACOS_UNABLE_TO_WRITE_USER_TCC_DB, {

--- a/src/commands/setup/macOS/updateTccDb.ts
+++ b/src/commands/setup/macOS/updateTccDb.ts
@@ -196,6 +196,7 @@ export function updateTccDb(path: string): void {
     try {
       execFileSync("sqlite3", [path, query], {
         encoding: "utf8",
+        stdio: "ignore",
       });
     } catch (cause) {
       throw new Error(ERR_SETUP_MACOS_UNABLE_TO_WRITE_USER_TCC_DB, {


### PR DESCRIPTION
# Issue

No issue

## Details

Occasionally see errors like:

```
Cause: Error: Command failed: sqlite3 "$HOME/Library/Application Support/com.apple.TCC/TCC.db" "INSERT OR IGNORE INTO access VALUES('kTCCServicePostEvent','/usr/local/opt/runner/runprovisioner.sh',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,0,1786869837,NULL,NULL,'UNUSED',[1786869837](tel:1786869837));"
Error: stepping, database is locked (5)
```

This change looks to add a 5s timeout for wait/retry when acquiring the write lock for the database.

## CheckList

- [ ] Has been tested (where required).
