### PR TITLE
fix: better timeouts and retries for tcc perms propagation

### DIFF
--- a/src/commands/setup/macOS/enableDoNotDisturb.ts
+++ b/src/commands/setup/macOS/enableDoNotDisturb.ts
@@ -104,15 +104,20 @@ export async function enableDoNotDisturb() {
       await promisify(exec)(enableFocusModeShellscript);
     } else if (platformMajor === 21) {
       // From macOS 12 Monterey (Darwin 21) there is no known way to enable DND via system defaults
-      await retryOnError(() => runAppleScript(enableFocusModeAppleScript));
+      await retryOnError(() => runAppleScript(enableFocusModeAppleScript), {
+        retries: 5,
+        delay: 500,
+      });
     } else {
       const { stdout: locale } = await promisify(exec)(getLocale);
 
       // From macOS 13 Ventura (Darwin 22) there is no known way to enable DND via system settings
-      await retryOnError(() =>
-        runAppleScript(
-          enableFocusModeVenturaAppleScript(locale, platformMajor),
-        ),
+      await retryOnError(
+        () =>
+          runAppleScript(
+            enableFocusModeVenturaAppleScript(locale, platformMajor),
+          ),
+        { retries: 5, delay: 500 },
       );
     }
   } catch (cause) {

--- a/src/commands/setup/macOS/runAppleScript.ts
+++ b/src/commands/setup/macOS/runAppleScript.ts
@@ -1,6 +1,6 @@
 import { execFile } from "child_process";
 
-export const DEFAULT_TIMEOUT = 10000;
+export const DEFAULT_TIMEOUT = 120;
 export const DEFAULT_MAX_BUFFER = 1000 * 1000 * 100;
 
 export async function runAppleScript<T = string | void>(
@@ -28,7 +28,7 @@ end tell"
 		
 		delay 0.2
 	end repeat
-end doWithTimeout
+end withTimeout
 `;
 
   return (await new Promise<string | void>((resolve, reject) => {

--- a/src/commands/setup/macOS/setup.ts
+++ b/src/commands/setup/macOS/setup.ts
@@ -30,7 +30,7 @@ export async function setup({
 }: MacOSSetupOptions = {}): Promise<void> {
   if (!macosIgnoreTccDb) {
     try {
-      updateTccDb(USER_PATH);
+      await updateTccDb(USER_PATH);
     } catch (e) {
       if (ci) {
         throw e;
@@ -43,7 +43,7 @@ export async function setup({
     }
 
     try {
-      updateTccDb(SYSTEM_PATH);
+      await updateTccDb(SYSTEM_PATH);
     } catch {
       // Swallow error - most CI don't allow system configuration
     }

--- a/src/commands/setup/macOS/updateTccDb.ts
+++ b/src/commands/setup/macOS/updateTccDb.ts
@@ -184,7 +184,7 @@ const getEntries = (): string[] => {
 export const USER_PATH = `${homedir()}/Library/Application Support/com.apple.TCC/TCC.db`;
 export const SYSTEM_PATH = "/Library/Application Support/com.apple.TCC/TCC.db";
 
-export function updateTccDb(path: string): void {
+export async function updateTccDb(path: string): Promise<void> {
   const osRelease = release();
   const isSonomaOrNewer = parseInt(osRelease.split(".")[0], 10) >= 23;
 
@@ -204,4 +204,7 @@ export function updateTccDb(path: string): void {
       });
     }
   }
+
+  // 1s sleep to give cache for updates to propagate
+  await new Promise((resolve) => setTimeout(resolve, 1000));
 }


### PR DESCRIPTION
# Issue

No issue.

## Details

Occasionally see apple event permission errors when really the successful TCC.db update should have covered it. There is potential propagation time + caches, so adding more timeouts and retries to see if improves success rate for DnD steps etc.

## CheckList

- [ ] Has been tested (where required).
